### PR TITLE
fix: no-plusplus warning, limit increments to loops

### DIFF
--- a/configs/base.js
+++ b/configs/base.js
@@ -100,8 +100,9 @@ const config = [
         }
       ],
 
-      // no-plusplus: Disabled to allow increment/decrement operators
-      'no-plusplus': 0,
+      // no-plusplus: Set to warning; allow ++/-- only in for-loop afterthoughts
+      // Example: for (let i = 0; i < n; i++) { /* i++ allowed here */ }
+      'no-plusplus': [1, { allowForLoopAfterthoughts: true }],
 
       // no-unsafe-optional-chaining: Set to error with disallowArithmeticOperators
       'no-unsafe-optional-chaining': [

--- a/tests/__fixtures__/custom.no-plusplus.js
+++ b/tests/__fixtures__/custom.no-plusplus.js
@@ -1,0 +1,36 @@
+/**
+ * FIXTURE: Validate no-plusplus configuration
+ *
+ * - 'no-plusplus': [1, { allowForLoopAfterthoughts: true }]
+ * - Intent:
+ *   - Allow ++/-- only in for-loop afterthoughts
+ *   - Disallow standalone increments/decrements elsewhere
+ */
+
+// Valid: Allowed in for-loop afterthought
+export function validForLoop() {
+  for (let i = 0; i < 3; i++) {
+    // noop
+  }
+}
+
+// Invalid: Standalone increment (should be flagged)
+export function invalidIncrement() {
+  let count = 0;
+  count++; // expect warning
+  return count;
+}
+
+// Valid: Using += 1 instead of ++
+export function validIncrement() {
+  let count = 0;
+  count += 1;
+  return count;
+}
+
+// Invalid: Pre-decrement outside for-loop (should be flagged)
+export function invalidDecrement() {
+  let n = 2;
+  --n; // expect warning
+  return n;
+}

--- a/tests/__snapshots__/eslint.test.js.snap
+++ b/tests/__snapshots__/eslint.test.js.snap
@@ -1039,6 +1039,48 @@ exports[`Rule Customizations custom.no-extra-parens.js should allow parentheses 
 }
 `;
 
+exports[`Rule Customizations custom.no-plusplus.js should disallow ++/-- except in for-loop afterthought (Note: Enabled as warning with allowForLoopAfterthoughts: true) 1`] = `
+{
+  "errorCount": 0,
+  "filePath": "custom.no-plusplus.js",
+  "filtering": {
+    "appliedFilters": [
+      "no-undef",
+      "jsdoc/require-jsdoc",
+      "jsdoc/tag-lines",
+      "jsdoc/require-param",
+      "jsdoc/require-returns",
+      "arrow-body-style",
+      "@stylistic/max-statements-per-line",
+      "@stylistic/padding-line-between-statements",
+    ],
+    "ruleBreakdown": {
+      "@stylistic/padding-line-between-statements": 6,
+      "jsdoc/require-jsdoc": 4,
+    },
+    "totalFiltered": 10,
+  },
+  "messages": [
+    {
+      "column": 3,
+      "line": 20,
+      "message": "Unary operator '++' used.",
+      "ruleId": "no-plusplus",
+      "severity": "warning",
+    },
+    {
+      "column": 3,
+      "line": 34,
+      "message": "Unary operator '--' used.",
+      "ruleId": "no-plusplus",
+      "severity": "warning",
+    },
+  ],
+  "totalIssues": 2,
+  "warningCount": 2,
+}
+`;
+
 exports[`Rule Customizations custom.space-before-function-paren.js should enforce consistent spacing in various code constructs (Note: Configured to require space before function parentheses for anonymous and async arrow functions, no space for named functions) 1`] = `
 {
   "errorCount": 2,

--- a/tests/eslint.test.js
+++ b/tests/eslint.test.js
@@ -183,6 +183,18 @@ describe('Rule Customizations', () => {
       rule: '@stylistic/no-extra-parens',
       note: 'Configured allowNodesInSpreadElement to allow parentheses around logical expressions in spread elements',
       disableRules: [...global.FILTERABLE_RULES.documentation, ...global.FILTERABLE_RULES.style]
+    },
+    {
+      file: 'custom.no-plusplus.js',
+      description: 'should disallow ++/-- except in for-loop afterthought',
+      rule: 'no-plusplus',
+      note: 'Enabled as warning with allowForLoopAfterthoughts: true',
+      disableRules: [...global.FILTERABLE_RULES.documentation, ...global.FILTERABLE_RULES.style],
+      testNotes: [
+        'Expect warnings for count++ and --n outside for-loop afterthoughts',
+        'Expect no warnings for i++ in for-loop afterthought',
+        'Expect no issues for the "+= 1" example'
+      ]
     }
   ])('$file $description (Note: $note)', async ({ file, rule, disableRules }) => {
     const result = await global.lintAndProcessFile(file, { disableRules, testRule: rule });


### PR DESCRIPTION
## What's included
<!-- List your changes/additions, or commits -->
- fix: no-plusplus warning, limit increments to loops

### Notes
- move no-plusplus to a warning but allow increments in loops
<!-- Anything funky about your updates. Or issues that aren't resolved by this merge request, things of note? -->

## How to test
<!-- Are there directions to test/review? -->

### Coverage and basic unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm test`
1. confirm tests come back clean
<!--
### Interactive unit test check
1. update the NPM packages with `$ npm install`
1. `$ npm run test:dev`
-->

## Example
<!-- Append a demo/screenshot/animated gif, or a link to the aforementioned, of the cli output -->
...

## Updates issue/story
<!-- What issue/story does this update, i.e Updates #33 -->
ongoing